### PR TITLE
query fixed it

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-linux)
+      racc (~> 1.4)
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -242,6 +244,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap
@@ -270,4 +273,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.3.5
+   2.3.10

--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,5 +1,7 @@
 class CyclesController < ApplicationController
   def index
-    @cycles = Cycle.all
+    #@cycles = Cycle.all
+    #A simple SQL query to only show the entries where public_status was true
+    @cycles = Cycle.where(public_status: true)
   end
 end


### PR DESCRIPTION
Active Record Query on index method instead of general one summarizing the instance